### PR TITLE
新增 `!sb skip`；改进 `!sb view` 结束后行为；实现 #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The following shows a list of functionalities of the ***scoreboardHelper*** pulg
    !sb help
    ```
 
+4. Skip current displaying scoreboard.
+
+   ```
+   !sb skip
+   ```
+
 ### For Server OPerators
 
 1. Toggle scoreboard cycling. (Case insensitive)

--- a/scoreboardHelper/scoreboardHelper.py
+++ b/scoreboardHelper/scoreboardHelper.py
@@ -43,8 +43,8 @@ class ScoreboardHelper(QtCore.QObject):
         self.cycle_index = 0
         self.cycle_timer = QtCore.QTimer(self)
         self.cycle_timer.timeout.connect(self.cycle_timer_action)   # type: ignore[attr-defined]
-        self.std_cyc_interval = self.configs.get('sec_between_cycle', self._default_cycle_interval)    # second
-        self.cycle_timer.start(self.std_cyc_interval * 1000)      # start cycle timer
+        self.std_cyc_interval = self.configs.get('sec_between_cycle', self._default_cycle_interval) * 1000    # msec
+        self.cycle_timer.start(self.std_cyc_interval)      # start cycle timer
         self._cycle_remaining_time = 0   # ms
 
         # connect signals and slots
@@ -174,10 +174,10 @@ class ScoreboardHelper(QtCore.QObject):
             self.cycle_timer.stop()
 
         self.core.write_server(f'/scoreboard objectives setdisplay sidebar {sb_name}')
-        interval = self.configs.get('sec_view_stay', self._default_view_stay)
-        self.utils.tell(player, f'Viewing \'{sb_name}\' for {interval} seconds.')
+        view_interval = self.configs.get('sec_view_stay', self._default_view_stay)
+        self.utils.tell(player, f'Viewing \'{sb_name}\' for {view_interval} seconds.')
         self.view_timer = QtCore.QTimer(self)
-        self.view_timer.singleShot(interval * 1000, self.view_timer_end)   # do view_timer_end() once after interval
+        self.view_timer.singleShot(view_interval * 1000, self.view_timer_end)   # do view_timer_end() once after interval
 
 
     def skip_sb(self, player, args: list):
@@ -192,6 +192,8 @@ class ScoreboardHelper(QtCore.QObject):
         else:   # TODO: permission control?
             self.logger.debug('skip_sb(): view timer is inactive.')
             self.cycle_timer_action(forced=True)
+            if self.cycle_enabled:
+                self.cycle_timer.start(self.std_cyc_interval)
         
         self.utils.tell(player, f'Skipped displaying scoreborad.')
 


### PR DESCRIPTION
1. 新增 `!sb skip` 命令，可自 view 状态或 cycle（正常显示）状态中立即跳过当前显示的计分板；
2. 改进 `!sb view` 结束后表现。现在 view 结束后 cycle 计时器会接着剩余时间开始计时，而非重新开始（如启用了 cycle）；
3. 实现 issue #1. 现在 cycle 会在最后一个玩家下线时暂停、第一个玩家上线时恢复。

部分功能测试结果截图：
<img width="1165" height="1049" alt="56e15254f5ea094025e78985ad3174ec" src="https://github.com/user-attachments/assets/ece42fde-bd59-4a14-bc4d-3657f663e123" />
